### PR TITLE
ci: add Windows build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
             target: bun-darwin-x64
             artifact: vers-agent-darwin-x64
             can_test: false  # Cross-compiled, can't test on ARM runner
+          - os: windows-latest
+            target: bun-windows-x64
+            artifact: vers-agent-windows-x64.exe
+            can_test: true
 
     runs-on: ${{ matrix.os }}
 
@@ -66,6 +70,7 @@ jobs:
 
       - name: Test binary
         if: matrix.can_test
+        shell: bash
         run: ./${{ matrix.artifact }} --help
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
Add Windows x64 build target to CI matrix.

## Build Targets
| OS | Target | Artifact |
|----|--------|----------|
| ubuntu-latest | bun-linux-x64 | vers-agent-linux-x64 |
| macos-latest | bun-darwin-arm64 | vers-agent-darwin-arm64 |
| macos-latest | bun-darwin-x64 | vers-agent-darwin-x64 |
| **windows-latest** | **bun-windows-x64** | **vers-agent-windows-x64.exe** |

🤖 Generated with [Claude Code](https://claude.ai/code)