### PR TITLE
feat(orchestrator): add autonomous monitoring (health monitor + watchdog)

### DIFF
--- a/docs/PLAN_AUTONOMOUS_OPS.md
+++ b/docs/PLAN_AUTONOMOUS_OPS.md
@@ -1,0 +1,523 @@
+# Autonomous Operation Implementation Plan
+
+## Overview
+
+Add three components to enable unattended, self-healing operation:
+
+1. **Health Monitor** - Periodic health checks on all managed VMs
+2. **Self-Healer** - Automatically fix issues (recreate VMs, cancel stuck tasks)
+3. **Watchdog** - Top-level supervisor for cleanup and consistency
+
+---
+
+## Current State Summary
+
+### What We Have ✅
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| VM primitives | Complete | `createVm()`, `branch()`, `deleteVm()` via vers-sdk |
+| Basic health check | Works | `curl /health` via SSH in bootstrap |
+| Event streaming | Complete | SSE with reconnect, 1000-event buffer |
+| VM metadata persistence | Basic | JSON file, tracks status/task/approach |
+| Task lifecycle | Complete | Full state machine with cancel support |
+| Connection tracking | Partial | Status enum but no heartbeat |
+
+### What's Missing ❌
+
+| Feature | Complexity | Notes |
+|---------|------------|-------|
+| Periodic health monitor | Low | Timer + existing health check |
+| Stale VM detection | Low | Add `lastEventAt` tracking |
+| Auto VM recreation | Medium | Reconnect flow needs care |
+| Stuck task detection | Medium | Need timeout enforcement |
+| Branch cleanup | Low | Age-based pruning |
+| Circuit breaker | Medium | Failure rate tracking |
+| Watchdog service | Low | Periodic scan loop |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Extend Metadata (Low Risk)
+
+**Files:** `src/orchestrator/index.ts`, `src/protocol/acp-types.ts`
+
+Extend `VmMetadata` to track health-related fields:
+
+```typescript
+interface VmMetadata {
+  // Existing
+  task?: string;
+  approach?: string;
+  status: VmStatus;
+  createdAt: string;
+  parentId?: string;
+
+  // NEW: Health tracking
+  lastHealthCheckAt?: string;    // Last successful health check
+  lastEventAt?: string;          // Last event received
+  healthScore?: number;          // 0-100, computed from checks
+  consecutiveFailures?: number;  // For circuit breaker
+  lastError?: string;            // Most recent error
+  recoveryAttempts?: number;     // How many times we've tried to fix
+}
+
+type VmStatus =
+  | "starting"    // Being created
+  | "ready"       // Healthy, idle
+  | "busy"        // Running a task
+  | "completed"   // Task finished successfully
+  | "failed"      // Task failed
+  | "unhealthy"   // Health check failing    <- NEW
+  | "recovering"; // Being recreated         <- NEW
+```
+
+**Effort:** ~30 min
+**Risk:** None - additive change
+
+---
+
+### Phase 2: Health Monitor (Low Risk)
+
+**New file:** `src/orchestrator/health-monitor.ts`
+
+A simple timer-based service that:
+1. Iterates all managed VMs every N seconds
+2. Pings each VM's `/health` endpoint
+3. Updates `lastHealthCheckAt` and `healthScore`
+4. Emits events for status changes
+
+```typescript
+export interface HealthMonitorConfig {
+  intervalMs: number;           // Default: 30000 (30s)
+  timeoutMs: number;            // Default: 5000 (5s per check)
+  unhealthyThreshold: number;   // Default: 3 consecutive failures
+}
+
+export class HealthMonitor {
+  private timer: Timer | null = null;
+  private running = false;
+
+  start(): void;
+  stop(): void;
+
+  // Manual check (for testing)
+  async checkVm(vmId: string): Promise<HealthCheckResult>;
+  async checkAll(): Promise<Map<string, HealthCheckResult>>;
+
+  // Subscribe to health events
+  onHealthChange(cb: (vmId: string, status: HealthStatus) => void): () => void;
+}
+
+interface HealthCheckResult {
+  vmId: string;
+  healthy: boolean;
+  responseTimeMs: number;
+  error?: string;
+  metrics?: {
+    prompts: number;
+    sessions: number;
+    queueLength: number;
+  };
+}
+```
+
+**Implementation approach:**
+1. Use existing `execute(vmId, "curl -s http://localhost:80/health")` from `src/vm/index.ts`
+2. Parse JSON response properly (not just string grep)
+3. Track consecutive failures for unhealthy detection
+4. Update metadata after each check
+
+**Effort:** ~2-3 hours
+**Risk:** Low - uses existing primitives
+**Experimental:** None - straightforward polling
+
+---
+
+### Phase 3: Self-Healer (Medium Risk)
+
+**New file:** `src/orchestrator/self-healer.ts`
+
+Listens for health events and takes corrective action:
+
+```typescript
+export interface SelfHealerConfig {
+  maxRecoveryAttempts: number;  // Default: 3
+  recoveryDelayMs: number;      // Default: 5000
+  taskTimeoutMs: number;        // Default: 300000 (5 min)
+}
+
+export class SelfHealer {
+  constructor(
+    private healthMonitor: HealthMonitor,
+    private config: SelfHealerConfig
+  );
+
+  start(): void;  // Subscribe to health events
+  stop(): void;
+
+  // Healing strategies
+  private async healUnresponsive(vmId: string): Promise<HealResult>;
+  private async healStuckTask(vmId: string): Promise<HealResult>;
+  private async recreateFromParent(vmId: string): Promise<HealResult>;
+}
+
+interface HealResult {
+  success: boolean;
+  action: "recreated" | "cancelled" | "restarted" | "abandoned";
+  newVmId?: string;  // If recreated
+  error?: string;
+}
+```
+
+**Healing strategies:**
+
+1. **Unresponsive VM** (health check fails 3+ times):
+   - Get parent VM ID from metadata
+   - Delete unresponsive VM
+   - Branch from parent (or create new root if no parent)
+   - Reconnect client
+   - Re-run task if it was in progress
+
+2. **Stuck Task** (busy status for > timeout):
+   - Cancel task via `client.cancel()`
+   - Wait briefly for cancellation
+   - If still stuck, recreate VM
+   - Mark task as failed
+
+3. **Circuit Breaker** (too many failures):
+   - If a VM has been recreated 3+ times
+   - Mark it as "abandoned"
+   - Don't auto-heal anymore
+   - Log for human review
+
+**Effort:** ~4-6 hours
+**Risk:** Medium - need to handle edge cases
+**Experimental areas:**
+- Task re-running after VM recreation (need to preserve context)
+- Race conditions between health check and task completion
+- Handling VMs that are slow but not dead
+
+---
+
+### Phase 4: Stuck Task Detection (Medium Risk)
+
+**Modify:** `src/orchestrator/index.ts`
+
+Add timeout tracking to `runPrompt()`:
+
+```typescript
+export async function runPrompt(
+  vmId: string,
+  text: string,
+  options?: { timeoutMs?: number }
+): Promise<{ success: boolean; error?: string; timedOut?: boolean }> {
+  const timeout = options?.timeoutMs ?? 300000; // 5 min default
+
+  updateVmMetadata(vmId, { status: "busy" });
+
+  const startTime = Date.now();
+
+  // Create a promise that rejects on timeout
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => reject(new Error("Task timed out")), timeout);
+  });
+
+  try {
+    await Promise.race([
+      managed.client.prompt(text),
+      timeoutPromise
+    ]);
+    updateVmMetadata(vmId, { status: "ready" });
+    return { success: true };
+  } catch (e) {
+    if (e.message === "Task timed out") {
+      updateVmMetadata(vmId, { status: "unhealthy" });
+      return { success: false, timedOut: true, error: "Task timed out" };
+    }
+    // ... existing error handling
+  }
+}
+```
+
+**Alternative approach:** Track `taskStartedAt` in metadata and let health monitor detect stuck tasks by checking duration.
+
+**Effort:** ~1-2 hours
+**Risk:** Medium - timeout behavior with SSE streams
+**Experimental:** How `client.prompt()` behaves when cancelled mid-stream
+
+---
+
+### Phase 5: Watchdog (Low Risk)
+
+**New file:** `src/orchestrator/watchdog.ts`
+
+Top-level supervisor that runs less frequently:
+
+```typescript
+export interface WatchdogConfig {
+  intervalMs: number;            // Default: 300000 (5 min)
+  staleMetadataAgeMs: number;   // Default: 86400000 (24 hours)
+  maxBranchesPerRoot: number;   // Default: 20
+}
+
+export class Watchdog {
+  start(): void;
+  stop(): void;
+
+  // Individual checks (for testing)
+  async cleanupStaleMetadata(): Promise<number>;
+  async cleanupOrphanedBranches(): Promise<number>;
+  async checkConsistency(): Promise<ConsistencyReport>;
+}
+
+interface ConsistencyReport {
+  vmCount: number;
+  metadataCount: number;
+  orphanedMetadata: string[];   // Metadata for deleted VMs
+  missingMetadata: string[];    // VMs without metadata
+  staleBranches: string[];      // Old branches to clean up
+}
+```
+
+**Tasks:**
+
+1. **Metadata cleanup:**
+   - Load metadata from JSON
+   - Call `listVms()` from vers API
+   - Delete metadata for VMs that no longer exist
+
+2. **Branch cleanup:**
+   - Find branches older than threshold
+   - Find branches with status "completed" or "failed"
+   - Delete them
+
+3. **Consistency check:**
+   - Compare in-memory `managedVms` vs JSON vs vers API
+   - Log discrepancies
+   - Optionally auto-fix
+
+**Effort:** ~2-3 hours
+**Risk:** Low - read-heavy, deletes are explicit
+**Experimental:** None
+
+---
+
+### Phase 6: Integration & Config
+
+**Modify:** `src/orchestrator/index.ts`
+
+Add startup/shutdown for monitoring services:
+
+```typescript
+let healthMonitor: HealthMonitor | null = null;
+let selfHealer: SelfHealer | null = null;
+let watchdog: Watchdog | null = null;
+
+export function startMonitoring(config?: MonitoringConfig): void {
+  healthMonitor = new HealthMonitor(config?.health);
+  selfHealer = new SelfHealer(healthMonitor, config?.healing);
+  watchdog = new Watchdog(config?.watchdog);
+
+  healthMonitor.start();
+  selfHealer.start();
+  watchdog.start();
+}
+
+export function stopMonitoring(): void {
+  watchdog?.stop();
+  selfHealer?.stop();
+  healthMonitor?.stop();
+}
+```
+
+**New config file:** `~/.vers-agent/orchestrator/config.json`
+
+```json
+{
+  "monitoring": {
+    "enabled": true,
+    "health": {
+      "intervalMs": 30000,
+      "timeoutMs": 5000,
+      "unhealthyThreshold": 3
+    },
+    "healing": {
+      "enabled": true,
+      "maxRecoveryAttempts": 3,
+      "taskTimeoutMs": 300000
+    },
+    "watchdog": {
+      "intervalMs": 300000,
+      "staleMetadataAgeMs": 86400000
+    }
+  }
+}
+```
+
+**Effort:** ~1 hour
+**Risk:** Low
+
+---
+
+## File Structure
+
+```
+src/orchestrator/
+├── index.ts                 # Existing - add startMonitoring()
+├── health-monitor.ts        # NEW - periodic health checks
+├── self-healer.ts           # NEW - auto-recovery logic
+├── watchdog.ts              # NEW - cleanup and consistency
+└── config.ts                # NEW - monitoring configuration
+```
+
+---
+
+## Risk Assessment
+
+### Low Risk (Straightforward)
+- Health monitor polling - just a timer + existing curl
+- Metadata extension - additive schema change
+- Watchdog cleanup - read-heavy, explicit deletes
+- Configuration - standard JSON parsing
+
+### Medium Risk (Needs Care)
+- Self-healer recreate flow - must handle edge cases:
+  - What if parent VM is also dead?
+  - What if branch fails?
+  - What if task was mid-completion?
+- Stuck task timeout - SSE stream behavior when cancelled
+- Circuit breaker - need to avoid infinite loops
+
+### Experimental (Unknown Behavior)
+- **Task context preservation**: If a VM dies mid-task, can we resume? Currently no - we'd have to restart from scratch or use session persistence.
+- **Network flakiness**: How often do Vers VMs become transiently unreachable? Unknown. May need to tune thresholds.
+- **Golden image staleness**: If the golden commit becomes outdated, restoration may fail. Need fallback.
+
+---
+
+## Implementation Order
+
+### Part A: Non-Experimental (Implement First)
+
+These are straightforward - just timers, polling, and CRUD on existing primitives:
+
+```
+1. Extend Metadata (30 min)
+   - Add health tracking fields to VmMetadata
+   - No behavior change, just schema
+
+2. Health Monitor (2-3 hrs)
+   - Timer + existing execute(vmId, "curl /health")
+   - Parse JSON response
+   - Update metadata with results
+   - Emit events on status change
+
+3. Watchdog (2-3 hrs)
+   - Periodic cleanup of stale metadata
+   - Compare JSON file vs vers API
+   - Delete orphaned entries
+   - Age-based branch pruning
+
+4. Config & Integration (1 hr)
+   - Config file for intervals/thresholds
+   - startMonitoring() / stopMonitoring()
+```
+
+**Total Part A: ~6-8 hours**
+
+### Part B: Experimental (Implement Later)
+
+These have unknowns that need investigation or careful design:
+
+```
+5. Stuck Task Detection (1-2 hrs)
+   EXPERIMENTAL: SSE stream timeout behavior
+   - What happens when we timeout client.prompt()?
+   - Does cancel() work reliably mid-stream?
+   - Need to test with real agent
+
+6. Self-Healer (4-6 hrs)
+   EXPERIMENTAL: Multiple unknowns
+   - Task resumption: restart vs continue vs fail?
+   - Race conditions: health check vs task completion
+   - Parent chain: what if parent VM is also dead?
+   - Network flakiness: what thresholds work?
+```
+
+**Total Part B: ~5-8 hours**
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Health check parsing (mock curl responses)
+- Metadata update logic
+- Timeout calculations
+- Circuit breaker state machine
+
+### Integration Tests (require VMs)
+- Create VM → health check → verify healthy
+- Create VM → stop agent → verify unhealthy
+- Create VM → run long task → verify stuck detection
+- Self-healer: kill VM → verify recreation
+
+### Manual Testing
+- Start orchestrator with monitoring
+- Create 3-5 VMs
+- Manually kill agent on one VM (via SSH)
+- Observe: health check fails → self-healer kicks in → VM recreated
+- Run long task → observe stuck detection
+
+---
+
+## Open Questions
+
+1. **Task resumption**: When we recreate a VM, should we:
+   - A) Restart the task from scratch
+   - B) Try to load session and continue
+   - C) Mark as failed and notify caller
+
+   Recommendation: Start with (C), add (A) later.
+
+2. **Notification mechanism**: How should we surface issues?
+   - Log only (current approach)
+   - Add `onIssue()` callback
+   - Emit events via SSE
+
+   Recommendation: All three - logs always, callbacks for programmatic use, events for CLI.
+
+3. **Healing authorization**: Should auto-healing be:
+   - Always on (default)
+   - Opt-in per VM
+   - Configurable globally
+
+   Recommendation: Global config with per-VM override.
+
+4. **Resource limits**: Should we enforce:
+   - Max concurrent VMs
+   - Max branches per root
+   - Max total branches
+
+   Recommendation: Yes, with sensible defaults (10, 20, 50).
+
+---
+
+## Summary
+
+| Component | Effort | Risk | Experimental |
+|-----------|--------|------|--------------|
+| Metadata extension | 30 min | None | No |
+| Health Monitor | 2-3 hrs | Low | No |
+| Watchdog | 2-3 hrs | Low | No |
+| Stuck Task Detection | 1-2 hrs | Medium | Timeout behavior |
+| Self-Healer | 4-6 hrs | Medium | Task resumption, race conditions |
+| Config & Integration | 1 hr | Low | No |
+| **Total** | **12-16 hrs** | **Medium** | **Some** |
+
+The foundation is solid. Most work is straightforward timer/polling logic using existing primitives. The main experimental areas are:
+1. Task resumption after VM recreation
+2. Network flakiness thresholds
+3. Race conditions between healing and normal operations

--- a/src/orchestrator/health-monitor.ts
+++ b/src/orchestrator/health-monitor.ts
@@ -1,0 +1,346 @@
+/**
+ * Health Monitor - Periodic health checks for managed VMs
+ *
+ * Runs on a timer, checks each VM's /health endpoint via SSH,
+ * updates metadata with results, and emits events on status changes.
+ */
+
+import { execute } from "../vm/index";
+import { loadMetadata, updateVmMetadata, type VmMetadata, type VmStatus } from "./index";
+import { logStream } from "../utils/log-stream";
+import { type HealthMonitorConfig, DEFAULT_HEALTH_CONFIG } from "./monitoring-config";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface HealthCheckResult {
+  vmId: string;
+  healthy: boolean;
+  responseTimeMs: number;
+  timestamp: string;
+  error?: string;
+  metrics?: {
+    status: string;
+    initialized: boolean;
+    sessionId?: string;
+    prompts?: number;
+    sessions?: number;
+    queueLength?: number;
+    sseClients?: number;
+  };
+}
+
+export type HealthStatus = "healthy" | "unhealthy" | "unknown";
+
+export type HealthChangeCallback = (
+  vmId: string,
+  newStatus: HealthStatus,
+  result: HealthCheckResult
+) => void;
+
+// ============================================================
+// Health Monitor Class
+// ============================================================
+
+export class HealthMonitor {
+  private config: HealthMonitorConfig;
+  private timer: Timer | null = null;
+  private running = false;
+  private subscribers = new Set<HealthChangeCallback>();
+
+  // Track consecutive failures per VM (not persisted, resets on restart)
+  private failureCounts = new Map<string, number>();
+
+  constructor(config?: Partial<HealthMonitorConfig>) {
+    this.config = { ...DEFAULT_HEALTH_CONFIG, ...config };
+  }
+
+  /**
+   * Start the health monitor timer
+   */
+  start(): void {
+    if (this.running) {
+      logStream.debug("[health-monitor] Already running");
+      return;
+    }
+
+    this.running = true;
+    logStream.info("[health-monitor] Starting", {
+      intervalMs: this.config.intervalMs,
+      unhealthyThreshold: this.config.unhealthyThreshold,
+    });
+
+    // Run immediately, then on interval
+    this.runChecks();
+    this.timer = setInterval(() => this.runChecks(), this.config.intervalMs);
+  }
+
+  /**
+   * Stop the health monitor
+   */
+  stop(): void {
+    if (!this.running) return;
+
+    this.running = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    logStream.info("[health-monitor] Stopped");
+  }
+
+  /**
+   * Check if the monitor is running
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Subscribe to health status changes
+   */
+  onHealthChange(callback: HealthChangeCallback): () => void {
+    this.subscribers.add(callback);
+    return () => this.subscribers.delete(callback);
+  }
+
+  /**
+   * Run health checks on all managed VMs
+   */
+  async checkAll(): Promise<Map<string, HealthCheckResult>> {
+    const results = new Map<string, HealthCheckResult>();
+    const metadata = loadMetadata();
+    const vmIds = Object.keys(metadata).filter(id => {
+      // Guard against corrupted metadata with invalid vmIds
+      if (!id || id === "undefined" || id === "null") {
+        logStream.warn("[health-monitor] Skipping invalid vmId in metadata", { id });
+        return false;
+      }
+      return true;
+    });
+
+    logStream.debug("[health-monitor] Checking VMs", { count: vmIds.length });
+
+    // Run checks in parallel
+    const checks = vmIds.map(async (vmId) => {
+      const result = await this.checkVm(vmId);
+      results.set(vmId, result);
+      return result;
+    });
+
+    await Promise.allSettled(checks);
+    return results;
+  }
+
+  /**
+   * Check a single VM's health
+   */
+  async checkVm(vmId: string): Promise<HealthCheckResult> {
+    const startTime = Date.now();
+    const timestamp = new Date().toISOString();
+
+    try {
+      // Execute curl via SSH with timeout
+      const result = await Promise.race([
+        execute(vmId, "curl -s http://localhost:80/health"),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("Health check timeout")), this.config.timeoutMs)
+        ),
+      ]);
+
+      const responseTimeMs = Date.now() - startTime;
+
+      // Parse JSON response
+      let metrics: HealthCheckResult["metrics"];
+      try {
+        const json = JSON.parse(result.stdout);
+        metrics = {
+          status: json.status,
+          initialized: json.initialized,
+          sessionId: json.sessionId,
+          prompts: json.metrics?.prompts,
+          sessions: json.metrics?.sessions,
+          queueLength: json.metrics?.queueLength,
+          sseClients: json.metrics?.sseClients,
+        };
+      } catch {
+        // JSON parse failed but curl succeeded - partial health
+        logStream.debug("[health-monitor] Failed to parse health response", { vmId, stdout: result.stdout });
+      }
+
+      const healthy = metrics?.status === "ok";
+      const checkResult: HealthCheckResult = {
+        vmId,
+        healthy,
+        responseTimeMs,
+        timestamp,
+        metrics,
+      };
+
+      // Update state
+      this.handleCheckResult(vmId, checkResult);
+      return checkResult;
+
+    } catch (err) {
+      const responseTimeMs = Date.now() - startTime;
+      const error = err instanceof Error ? err.message : String(err);
+
+      const checkResult: HealthCheckResult = {
+        vmId,
+        healthy: false,
+        responseTimeMs,
+        timestamp,
+        error,
+      };
+
+      this.handleCheckResult(vmId, checkResult);
+      return checkResult;
+    }
+  }
+
+  /**
+   * Process a health check result and update state
+   */
+  private handleCheckResult(vmId: string, result: HealthCheckResult): void {
+    const metadata = loadMetadata();
+    const vm = metadata[vmId];
+    if (!vm) return;
+
+    const previousStatus = vm.status;
+    let newVmStatus: VmStatus = vm.status;
+
+    if (result.healthy) {
+      // Reset failure count on success
+      this.failureCounts.delete(vmId);
+
+      // Update metadata
+      updateVmMetadata(vmId, {
+        lastHealthCheckAt: result.timestamp,
+        healthScore: 100,
+        consecutiveFailures: 0,
+        lastError: undefined,
+      });
+
+      // If was unhealthy, mark as ready
+      if (previousStatus === "unhealthy") {
+        newVmStatus = "ready";
+        updateVmMetadata(vmId, { status: "ready" });
+        this.notifySubscribers(vmId, "healthy", result);
+      }
+
+    } else {
+      // Increment failure count
+      const failures = (this.failureCounts.get(vmId) ?? 0) + 1;
+      this.failureCounts.set(vmId, failures);
+
+      // Calculate health score (0-100 based on recent failures)
+      const healthScore = Math.max(0, 100 - (failures * 33));
+
+      // Update metadata
+      updateVmMetadata(vmId, {
+        lastHealthCheckAt: result.timestamp,
+        healthScore,
+        consecutiveFailures: failures,
+        lastError: result.error,
+      });
+
+      // Mark as unhealthy if threshold reached
+      if (failures >= this.config.unhealthyThreshold) {
+        // Don't mark as unhealthy if it's in a terminal state or recovering
+        if (!["completed", "failed", "recovering"].includes(previousStatus)) {
+          newVmStatus = "unhealthy";
+          updateVmMetadata(vmId, { status: "unhealthy" });
+          this.notifySubscribers(vmId, "unhealthy", result);
+
+          logStream.warn("[health-monitor] VM marked unhealthy", {
+            vmId,
+            failures,
+            error: result.error,
+          });
+        }
+      }
+    }
+
+    logStream.debug("[health-monitor] Check complete", {
+      vmId,
+      healthy: result.healthy,
+      responseTimeMs: result.responseTimeMs,
+      status: newVmStatus,
+    });
+  }
+
+  /**
+   * Check for stale VMs (no events for too long)
+   */
+  async checkStaleVms(): Promise<string[]> {
+    const metadata = loadMetadata();
+    const now = Date.now();
+    const staleVmIds: string[] = [];
+
+    for (const [vmId, vm] of Object.entries(metadata)) {
+      // Skip VMs in terminal states
+      if (["completed", "failed", "recovering"].includes(vm.status)) {
+        continue;
+      }
+
+      // Check last event time
+      if (vm.lastEventAt) {
+        const lastEventTime = new Date(vm.lastEventAt).getTime();
+        const timeSinceEvent = now - lastEventTime;
+
+        if (timeSinceEvent > this.config.eventTimeoutMs) {
+          staleVmIds.push(vmId);
+          logStream.warn("[health-monitor] VM is stale (no events)", {
+            vmId,
+            lastEventAt: vm.lastEventAt,
+            timeSinceEventMs: timeSinceEvent,
+          });
+        }
+      }
+    }
+
+    return staleVmIds;
+  }
+
+  /**
+   * Notify subscribers of health status change
+   */
+  private notifySubscribers(vmId: string, status: HealthStatus, result: HealthCheckResult): void {
+    for (const callback of this.subscribers) {
+      try {
+        callback(vmId, status, result);
+      } catch (err) {
+        logStream.debug("[health-monitor] Subscriber error", { error: err });
+      }
+    }
+  }
+
+  /**
+   * Run all health checks (called by timer)
+   */
+  private async runChecks(): Promise<void> {
+    if (!this.running) return;
+
+    try {
+      await this.checkAll();
+      await this.checkStaleVms();
+    } catch (err) {
+      logStream.error("[health-monitor] Error running checks", { error: err });
+    }
+  }
+
+  /**
+   * Get current failure count for a VM
+   */
+  getFailureCount(vmId: string): number {
+    return this.failureCounts.get(vmId) ?? 0;
+  }
+
+  /**
+   * Reset failure count for a VM (e.g., after manual intervention)
+   */
+  resetFailureCount(vmId: string): void {
+    this.failureCounts.delete(vmId);
+  }
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -21,12 +21,29 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync } from "fs";
 // Types
 // ============================================================
 
+export type VmStatus =
+  | "starting"    // Being created/bootstrapped
+  | "ready"       // Healthy and idle
+  | "busy"        // Running a task
+  | "completed"   // Task finished successfully
+  | "failed"      // Task failed
+  | "unhealthy"   // Health checks failing
+  | "recovering"; // Being recreated by self-healer
+
 export interface VmMetadata {
   task?: string;
   approach?: string;
-  status: "starting" | "ready" | "busy" | "completed" | "failed";
+  status: VmStatus;
   createdAt: string;
   parentId?: string;
+
+  // Health tracking (added for autonomous operation)
+  lastHealthCheckAt?: string;     // Last successful health check
+  lastEventAt?: string;           // Last event received from this VM
+  healthScore?: number;           // 0-100, computed from recent checks
+  consecutiveFailures?: number;   // For circuit breaker logic
+  lastError?: string;             // Most recent error message
+  recoveryAttempts?: number;      // How many times self-healer has tried
 }
 
 export interface ManagedVm {
@@ -47,7 +64,8 @@ function ensureDataDir(): void {
   mkdirSync(DATA_DIR, { recursive: true });
 }
 
-function loadMetadata(): Record<string, VmMetadata> {
+// Export for use by health monitor and watchdog
+export function loadMetadata(): Record<string, VmMetadata> {
   ensureDataDir();
   if (!existsSync(METADATA_FILE)) {
     return {};
@@ -64,14 +82,16 @@ function saveMetadata(metadata: Record<string, VmMetadata>): void {
   writeFileSync(METADATA_FILE, JSON.stringify(metadata, null, 2));
 }
 
-function updateVmMetadata(vmId: string, updates: Partial<VmMetadata>): void {
+// Export for use by health monitor and watchdog
+export function updateVmMetadata(vmId: string, updates: Partial<VmMetadata>): void {
   const all = loadMetadata();
   const existing = all[vmId] || { status: "starting" as const, createdAt: new Date().toISOString() };
   all[vmId] = { ...existing, ...updates } as VmMetadata;
   saveMetadata(all);
 }
 
-function removeVmMetadata(vmId: string): void {
+// Export for use by watchdog
+export function removeVmMetadata(vmId: string): void {
   const all = loadMetadata();
   delete all[vmId];
   saveMetadata(all);
@@ -125,9 +145,11 @@ export async function createManagedVm(
   registerVm(vmId, agentUrl);
   client.onNotification((notification) => {
     receiveVmEvent(vmId, notification);
+    // Track last event time for health monitoring
+    updateVmMetadata(vmId, { lastEventAt: new Date().toISOString() });
   });
 
-  updateVmMetadata(vmId, { status: "ready" });
+  updateVmMetadata(vmId, { status: "ready", lastHealthCheckAt: new Date().toISOString() });
 
   const managed: ManagedVm = { vmId, metadata: { ...metadata, status: "ready" }, client };
   managedVms.set(vmId, managed);
@@ -164,9 +186,11 @@ export async function branchVm(
   registerVm(vmId, agentUrl);
   client.onNotification((notification) => {
     receiveVmEvent(vmId, notification);
+    // Track last event time for health monitoring
+    updateVmMetadata(vmId, { lastEventAt: new Date().toISOString() });
   });
 
-  updateVmMetadata(vmId, { status: "ready" });
+  updateVmMetadata(vmId, { status: "ready", lastHealthCheckAt: new Date().toISOString() });
 
   const managed: ManagedVm = { vmId, metadata: { ...metadata, status: "ready" }, client };
   managedVms.set(vmId, managed);
@@ -216,7 +240,10 @@ export async function getManagedVm(vmId: string): Promise<ManagedVm | null> {
     registerVm(vmId, agentUrl);
     client.onNotification((notification) => {
       receiveVmEvent(vmId, notification);
+      // Track last event time for health monitoring
+      updateVmMetadata(vmId, { lastEventAt: new Date().toISOString() });
     });
+    updateVmMetadata(vmId, { lastHealthCheckAt: new Date().toISOString() });
   } catch {
     return null;
   }
@@ -327,4 +354,87 @@ export async function cleanupAll(): Promise<number> {
   }
 
   return deleted;
+}
+
+// ============================================================
+// Monitoring Integration
+// ============================================================
+
+import { HealthMonitor, type HealthCheckResult, type HealthStatus } from "./health-monitor";
+import { Watchdog } from "./watchdog";
+import { loadMonitoringConfig, type MonitoringConfig } from "./monitoring-config";
+import { logStream } from "../utils/log-stream";
+
+let healthMonitor: HealthMonitor | null = null;
+let watchdog: Watchdog | null = null;
+
+/**
+ * Start autonomous monitoring services
+ */
+export function startMonitoring(configOverride?: Partial<MonitoringConfig>): void {
+  const config = loadMonitoringConfig();
+  const mergedConfig = {
+    ...config,
+    ...configOverride,
+    health: { ...config.health, ...(configOverride?.health ?? {}) },
+    watchdog: { ...config.watchdog, ...(configOverride?.watchdog ?? {}) },
+  };
+
+  if (!mergedConfig.enabled) {
+    logStream.info("[orchestrator] Monitoring disabled by config");
+    return;
+  }
+
+  // Create and start health monitor
+  healthMonitor = new HealthMonitor(mergedConfig.health);
+  healthMonitor.onHealthChange((vmId: string, status: HealthStatus, result: HealthCheckResult) => {
+    logStream.info("[orchestrator] VM health changed", { vmId, status, error: result.error });
+    // Future: hook up self-healer here
+  });
+  healthMonitor.start();
+
+  // Create and start watchdog
+  watchdog = new Watchdog(mergedConfig.watchdog);
+  watchdog.start();
+
+  logStream.info("[orchestrator] Monitoring started", {
+    healthIntervalMs: mergedConfig.health.intervalMs,
+    watchdogIntervalMs: mergedConfig.watchdog.intervalMs,
+  });
+}
+
+/**
+ * Stop monitoring services
+ */
+export function stopMonitoring(): void {
+  if (healthMonitor) {
+    healthMonitor.stop();
+    healthMonitor = null;
+  }
+  if (watchdog) {
+    watchdog.stop();
+    watchdog = null;
+  }
+  logStream.info("[orchestrator] Monitoring stopped");
+}
+
+/**
+ * Check if monitoring is running
+ */
+export function isMonitoringRunning(): boolean {
+  return (healthMonitor?.isRunning() ?? false) || (watchdog?.isRunning() ?? false);
+}
+
+/**
+ * Get the health monitor instance (for direct access)
+ */
+export function getHealthMonitor(): HealthMonitor | null {
+  return healthMonitor;
+}
+
+/**
+ * Get the watchdog instance (for direct access)
+ */
+export function getWatchdog(): Watchdog | null {
+  return watchdog;
 }

--- a/src/orchestrator/monitoring-config.ts
+++ b/src/orchestrator/monitoring-config.ts
@@ -1,0 +1,135 @@
+/**
+ * Configuration for autonomous operation monitoring
+ */
+
+import { join } from "path";
+import { homedir } from "os";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface HealthMonitorConfig {
+  /** How often to check VM health (ms). Default: 30000 (30s) */
+  intervalMs: number;
+  /** Timeout for each health check (ms). Default: 5000 (5s) */
+  timeoutMs: number;
+  /** How many consecutive failures before marking unhealthy. Default: 3 */
+  unhealthyThreshold: number;
+  /** How long without events before considering stale (ms). Default: 120000 (2 min) */
+  eventTimeoutMs: number;
+}
+
+export interface WatchdogConfig {
+  /** How often to run watchdog (ms). Default: 300000 (5 min) */
+  intervalMs: number;
+  /** Delete metadata older than this (ms). Default: 86400000 (24 hours) */
+  staleMetadataAgeMs: number;
+  /** Delete completed/failed branches older than this (ms). Default: 3600000 (1 hour) */
+  staleBranchAgeMs: number;
+  /** Max branches per root VM before pruning. Default: 20 */
+  maxBranchesPerRoot: number;
+}
+
+export interface MonitoringConfig {
+  /** Enable monitoring. Default: true */
+  enabled: boolean;
+  /** Health monitor settings */
+  health: HealthMonitorConfig;
+  /** Watchdog settings */
+  watchdog: WatchdogConfig;
+}
+
+// ============================================================
+// Defaults
+// ============================================================
+
+export const DEFAULT_HEALTH_CONFIG: HealthMonitorConfig = {
+  intervalMs: 30000,           // 30 seconds
+  timeoutMs: 5000,             // 5 seconds per check
+  unhealthyThreshold: 3,       // 3 consecutive failures
+  eventTimeoutMs: 120000,      // 2 minutes without events
+};
+
+export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
+  intervalMs: 300000,          // 5 minutes
+  staleMetadataAgeMs: 86400000, // 24 hours
+  staleBranchAgeMs: 3600000,   // 1 hour
+  maxBranchesPerRoot: 20,
+};
+
+export const DEFAULT_MONITORING_CONFIG: MonitoringConfig = {
+  enabled: true,
+  health: DEFAULT_HEALTH_CONFIG,
+  watchdog: DEFAULT_WATCHDOG_CONFIG,
+};
+
+// ============================================================
+// Config Persistence
+// ============================================================
+
+const CONFIG_DIR = join(homedir(), ".vers-agent", "orchestrator");
+const CONFIG_FILE = join(CONFIG_DIR, "monitoring.json");
+
+function ensureConfigDir(): void {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+}
+
+/**
+ * Load monitoring config from disk, merging with defaults
+ */
+export function loadMonitoringConfig(): MonitoringConfig {
+  ensureConfigDir();
+
+  if (!existsSync(CONFIG_FILE)) {
+    return DEFAULT_MONITORING_CONFIG;
+  }
+
+  try {
+    const stored = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
+    // Deep merge with defaults
+    return {
+      enabled: stored.enabled ?? DEFAULT_MONITORING_CONFIG.enabled,
+      health: {
+        ...DEFAULT_HEALTH_CONFIG,
+        ...stored.health,
+      },
+      watchdog: {
+        ...DEFAULT_WATCHDOG_CONFIG,
+        ...stored.watchdog,
+      },
+    };
+  } catch {
+    return DEFAULT_MONITORING_CONFIG;
+  }
+}
+
+/**
+ * Save monitoring config to disk
+ */
+export function saveMonitoringConfig(config: MonitoringConfig): void {
+  ensureConfigDir();
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Update specific config values
+ */
+export function updateMonitoringConfig(updates: Partial<MonitoringConfig>): MonitoringConfig {
+  const current = loadMonitoringConfig();
+  const updated: MonitoringConfig = {
+    ...current,
+    ...updates,
+    health: {
+      ...current.health,
+      ...(updates.health ?? {}),
+    },
+    watchdog: {
+      ...current.watchdog,
+      ...(updates.watchdog ?? {}),
+    },
+  };
+  saveMonitoringConfig(updated);
+  return updated;
+}

--- a/src/orchestrator/watchdog.ts
+++ b/src/orchestrator/watchdog.ts
@@ -1,0 +1,330 @@
+/**
+ * Watchdog - Periodic cleanup and consistency checks
+ *
+ * Runs less frequently than health monitor. Handles:
+ * - Cleaning up stale metadata (VMs that no longer exist)
+ * - Pruning old branches (completed/failed branches)
+ * - Checking consistency between metadata and vers API
+ */
+
+import { listVms, deleteVm } from "../vm/index";
+import { loadMetadata, removeVmMetadata, type VmMetadata } from "./index";
+import { logStream } from "../utils/log-stream";
+import { type WatchdogConfig, DEFAULT_WATCHDOG_CONFIG } from "./monitoring-config";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface ConsistencyReport {
+  /** Total VMs in vers API */
+  vmCount: number;
+  /** Total VMs in our metadata */
+  metadataCount: number;
+  /** Metadata entries for VMs that no longer exist */
+  orphanedMetadata: string[];
+  /** VMs in vers API that we don't have metadata for */
+  missingMetadata: string[];
+  /** Branches that are old and could be cleaned up */
+  staleBranches: string[];
+  /** VMs with completed/failed status that could be cleaned up */
+  finishedBranches: string[];
+}
+
+export interface CleanupResult {
+  /** Number of metadata entries removed */
+  metadataRemoved: number;
+  /** Number of VMs deleted */
+  vmsDeleted: number;
+  /** Errors encountered */
+  errors: string[];
+}
+
+// ============================================================
+// Watchdog Class
+// ============================================================
+
+export class Watchdog {
+  private config: WatchdogConfig;
+  private timer: Timer | null = null;
+  private running = false;
+
+  constructor(config?: Partial<WatchdogConfig>) {
+    this.config = { ...DEFAULT_WATCHDOG_CONFIG, ...config };
+  }
+
+  /**
+   * Start the watchdog timer
+   */
+  start(): void {
+    if (this.running) {
+      logStream.debug("[watchdog] Already running");
+      return;
+    }
+
+    this.running = true;
+    logStream.info("[watchdog] Starting", {
+      intervalMs: this.config.intervalMs,
+    });
+
+    // Run after a delay (don't run immediately on startup)
+    this.timer = setInterval(() => this.runChecks(), this.config.intervalMs);
+  }
+
+  /**
+   * Stop the watchdog
+   */
+  stop(): void {
+    if (!this.running) return;
+
+    this.running = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    logStream.info("[watchdog] Stopped");
+  }
+
+  /**
+   * Check if the watchdog is running
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Check consistency between metadata and vers API
+   */
+  async checkConsistency(): Promise<ConsistencyReport> {
+    const [vms, metadata] = await Promise.all([
+      listVms(),
+      Promise.resolve(loadMetadata()),
+    ]);
+
+    const vmIds = new Set(vms.map(vm => vm.vm_id));
+    const metadataIds = new Set(Object.keys(metadata));
+
+    // Find orphaned metadata (we have metadata but VM doesn't exist)
+    const orphanedMetadata: string[] = [];
+    for (const id of metadataIds) {
+      if (!vmIds.has(id)) {
+        orphanedMetadata.push(id);
+      }
+    }
+
+    // Find missing metadata (VM exists but we don't have metadata)
+    const missingMetadata: string[] = [];
+    for (const id of vmIds) {
+      if (!metadataIds.has(id)) {
+        missingMetadata.push(id);
+      }
+    }
+
+    // Find stale branches (old completed/failed VMs)
+    const now = Date.now();
+    const staleBranches: string[] = [];
+    const finishedBranches: string[] = [];
+
+    for (const [vmId, vm] of Object.entries(metadata)) {
+      // Skip if VM doesn't exist in vers API
+      if (!vmIds.has(vmId)) continue;
+
+      const createdAt = new Date(vm.createdAt).getTime();
+      const age = now - createdAt;
+
+      // Check if finished (completed or failed)
+      if (vm.status === "completed" || vm.status === "failed") {
+        finishedBranches.push(vmId);
+
+        // Also mark as stale if old enough
+        if (age > this.config.staleBranchAgeMs) {
+          staleBranches.push(vmId);
+        }
+      }
+
+      // Also check for very old branches regardless of status
+      if (age > this.config.staleMetadataAgeMs) {
+        if (!staleBranches.includes(vmId)) {
+          staleBranches.push(vmId);
+        }
+      }
+    }
+
+    const report: ConsistencyReport = {
+      vmCount: vmIds.size,
+      metadataCount: metadataIds.size,
+      orphanedMetadata,
+      missingMetadata,
+      staleBranches,
+      finishedBranches,
+    };
+
+    logStream.debug("[watchdog] Consistency check", report);
+    return report;
+  }
+
+  /**
+   * Clean up orphaned metadata entries
+   */
+  async cleanupStaleMetadata(): Promise<number> {
+    const report = await this.checkConsistency();
+    let removed = 0;
+
+    for (const vmId of report.orphanedMetadata) {
+      try {
+        removeVmMetadata(vmId);
+        removed++;
+        logStream.info("[watchdog] Removed orphaned metadata", { vmId });
+      } catch (err) {
+        logStream.error("[watchdog] Failed to remove metadata", { vmId, error: err });
+      }
+    }
+
+    return removed;
+  }
+
+  /**
+   * Clean up old finished branches
+   * Only deletes VMs with status completed/failed that are older than staleBranchAgeMs
+   */
+  async cleanupFinishedBranches(): Promise<CleanupResult> {
+    const report = await this.checkConsistency();
+    const result: CleanupResult = {
+      metadataRemoved: 0,
+      vmsDeleted: 0,
+      errors: [],
+    };
+
+    for (const vmId of report.staleBranches) {
+      const metadata = loadMetadata()[vmId];
+      if (!metadata) continue;
+
+      // Only auto-delete completed/failed branches
+      if (metadata.status !== "completed" && metadata.status !== "failed") {
+        continue;
+      }
+
+      try {
+        logStream.info("[watchdog] Deleting stale branch", {
+          vmId,
+          status: metadata.status,
+          createdAt: metadata.createdAt,
+        });
+
+        await deleteVm(vmId);
+        result.vmsDeleted++;
+
+        removeVmMetadata(vmId);
+        result.metadataRemoved++;
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        result.errors.push(`${vmId}: ${error}`);
+        logStream.error("[watchdog] Failed to delete branch", { vmId, error });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Check for branches exceeding per-root limit
+   * Returns VM IDs that could be pruned (oldest first)
+   */
+  async findExcessBranches(): Promise<Map<string, string[]>> {
+    const vms = await listVms();
+    const metadata = loadMetadata();
+
+    // Group branches by root
+    const branchesByRoot = new Map<string, Array<{ vmId: string; createdAt: string }>>();
+
+    for (const vm of vms) {
+      // Find root (VM with no parent)
+      let rootId = vm.vm_id;
+      let current = vm;
+      while (current.parent) {
+        rootId = current.parent;
+        const parent = vms.find(v => v.vm_id === current.parent);
+        if (!parent) break;
+        current = parent;
+      }
+
+      // Add to root's branch list
+      if (!branchesByRoot.has(rootId)) {
+        branchesByRoot.set(rootId, []);
+      }
+      const vmMeta = metadata[vm.vm_id];
+      branchesByRoot.get(rootId)!.push({
+        vmId: vm.vm_id,
+        createdAt: vmMeta?.createdAt ?? new Date().toISOString(),
+      });
+    }
+
+    // Find roots with too many branches
+    const excess = new Map<string, string[]>();
+
+    for (const [rootId, branches] of branchesByRoot) {
+      if (branches.length > this.config.maxBranchesPerRoot) {
+        // Sort by creation time (oldest first)
+        branches.sort((a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
+
+        // Mark excess branches for pruning (keep newest ones)
+        const toRemove = branches.length - this.config.maxBranchesPerRoot;
+        const excessBranches = branches
+          .slice(0, toRemove)
+          .map(b => b.vmId)
+          // Don't remove the root itself
+          .filter(id => id !== rootId);
+
+        if (excessBranches.length > 0) {
+          excess.set(rootId, excessBranches);
+          logStream.warn("[watchdog] Root has excess branches", {
+            rootId,
+            total: branches.length,
+            excess: excessBranches.length,
+          });
+        }
+      }
+    }
+
+    return excess;
+  }
+
+  /**
+   * Run all watchdog checks (called by timer)
+   */
+  private async runChecks(): Promise<void> {
+    if (!this.running) return;
+
+    try {
+      logStream.debug("[watchdog] Running checks");
+
+      // Clean up orphaned metadata
+      const metadataRemoved = await this.cleanupStaleMetadata();
+      if (metadataRemoved > 0) {
+        logStream.info("[watchdog] Cleaned up orphaned metadata", { count: metadataRemoved });
+      }
+
+      // Clean up old finished branches
+      const cleanup = await this.cleanupFinishedBranches();
+      if (cleanup.vmsDeleted > 0) {
+        logStream.info("[watchdog] Cleaned up finished branches", {
+          deleted: cleanup.vmsDeleted,
+          errors: cleanup.errors.length,
+        });
+      }
+
+      // Check for excess branches (just log, don't auto-delete)
+      const excess = await this.findExcessBranches();
+      if (excess.size > 0) {
+        logStream.warn("[watchdog] Found roots with excess branches", {
+          roots: Array.from(excess.keys()),
+        });
+      }
+
+    } catch (err) {
+      logStream.error("[watchdog] Error running checks", { error: err });
+    }
+  }
+}

--- a/src/protocol/acp-types.ts
+++ b/src/protocol/acp-types.ts
@@ -485,10 +485,14 @@ export interface SessionIdUpdatedData {
 export interface VmInfo {
   vmId: string;
   parent?: string | null;
-  status: "starting" | "ready" | "busy" | "completed" | "failed";
+  status: "starting" | "ready" | "busy" | "completed" | "failed" | "unhealthy" | "recovering";
   task?: string;
   approach?: string;
   createdAt: string;
+  // Health tracking fields (optional)
+  lastHealthCheckAt?: string;
+  healthScore?: number;
+  lastError?: string;
 }
 
 export interface VmListResult {

--- a/tests/orchestrator/health-monitor.test.ts
+++ b/tests/orchestrator/health-monitor.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { HealthMonitor } from "../../src/orchestrator/health-monitor";
+
+// Mock the vm execute function
+const mockExecute = mock(() => Promise.resolve({
+  stdout: JSON.stringify({
+    status: "ok",
+    initialized: true,
+    sessionId: "test-session",
+    metrics: {
+      prompts: 5,
+      sessions: 2,
+      queueLength: 0,
+      sseClients: 1,
+    },
+  }),
+  stderr: "",
+}));
+
+// Mock loadMetadata
+const mockLoadMetadata = mock(() => ({
+  "vm-1": {
+    status: "ready",
+    createdAt: new Date().toISOString(),
+    task: "test task",
+  },
+  "vm-2": {
+    status: "busy",
+    createdAt: new Date().toISOString(),
+    task: "another task",
+  },
+}));
+
+// Mock updateVmMetadata
+const mockUpdateVmMetadata = mock(() => {});
+
+describe("HealthMonitor", () => {
+  let healthMonitor: HealthMonitor;
+
+  beforeEach(() => {
+    // Reset mocks
+    mockExecute.mockClear();
+    mockLoadMetadata.mockClear();
+    mockUpdateVmMetadata.mockClear();
+
+    healthMonitor = new HealthMonitor({
+      intervalMs: 1000,
+      timeoutMs: 500,
+      unhealthyThreshold: 2,
+      eventTimeoutMs: 5000,
+    });
+  });
+
+  afterEach(() => {
+    healthMonitor.stop();
+  });
+
+  describe("constructor", () => {
+    test("creates with default config", () => {
+      const monitor = new HealthMonitor();
+      expect(monitor).toBeDefined();
+      expect(monitor.isRunning()).toBe(false);
+      monitor.stop();
+    });
+
+    test("creates with custom config", () => {
+      const monitor = new HealthMonitor({
+        intervalMs: 5000,
+        unhealthyThreshold: 5,
+      });
+      expect(monitor).toBeDefined();
+      monitor.stop();
+    });
+  });
+
+  describe("start/stop", () => {
+    test("starts and stops correctly", () => {
+      expect(healthMonitor.isRunning()).toBe(false);
+
+      healthMonitor.start();
+      expect(healthMonitor.isRunning()).toBe(true);
+
+      healthMonitor.stop();
+      expect(healthMonitor.isRunning()).toBe(false);
+    });
+
+    test("handles multiple start calls", () => {
+      healthMonitor.start();
+      healthMonitor.start(); // Should not throw
+      expect(healthMonitor.isRunning()).toBe(true);
+    });
+
+    test("handles multiple stop calls", () => {
+      healthMonitor.start();
+      healthMonitor.stop();
+      healthMonitor.stop(); // Should not throw
+      expect(healthMonitor.isRunning()).toBe(false);
+    });
+  });
+
+  describe("onHealthChange", () => {
+    test("subscribes and unsubscribes", () => {
+      const callback = mock(() => {});
+      const unsubscribe = healthMonitor.onHealthChange(callback);
+
+      expect(typeof unsubscribe).toBe("function");
+
+      // Unsubscribe
+      unsubscribe();
+      // Should not throw
+    });
+  });
+
+  describe("getFailureCount", () => {
+    test("returns 0 for unknown VM", () => {
+      expect(healthMonitor.getFailureCount("unknown-vm")).toBe(0);
+    });
+  });
+
+  describe("resetFailureCount", () => {
+    test("does not throw for unknown VM", () => {
+      expect(() => healthMonitor.resetFailureCount("unknown-vm")).not.toThrow();
+    });
+  });
+});
+
+describe("HealthCheckResult parsing", () => {
+  test("parses valid health response", () => {
+    const response = {
+      status: "ok",
+      initialized: true,
+      sessionId: "test-session",
+      metrics: {
+        prompts: 5,
+        sessions: 2,
+        queueLength: 0,
+        sseClients: 1,
+      },
+    };
+
+    expect(response.status).toBe("ok");
+    expect(response.metrics.prompts).toBe(5);
+  });
+
+  test("handles missing metrics", () => {
+    const response = {
+      status: "ok",
+      initialized: true,
+    };
+
+    expect(response.status).toBe("ok");
+    expect((response as any).metrics).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/metadata.test.ts
+++ b/tests/orchestrator/metadata.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from "bun:test";
+import type { VmStatus, VmMetadata } from "../../src/orchestrator/index";
+
+describe("VmStatus", () => {
+  test("includes all expected statuses", () => {
+    const statuses: VmStatus[] = [
+      "starting",
+      "ready",
+      "busy",
+      "completed",
+      "failed",
+      "unhealthy",
+      "recovering",
+    ];
+
+    expect(statuses).toHaveLength(7);
+  });
+
+  test("starting is a valid status", () => {
+    const status: VmStatus = "starting";
+    expect(status).toBe("starting");
+  });
+
+  test("unhealthy is a valid status", () => {
+    const status: VmStatus = "unhealthy";
+    expect(status).toBe("unhealthy");
+  });
+
+  test("recovering is a valid status", () => {
+    const status: VmStatus = "recovering";
+    expect(status).toBe("recovering");
+  });
+});
+
+describe("VmMetadata", () => {
+  test("creates minimal metadata", () => {
+    const metadata: VmMetadata = {
+      status: "starting",
+      createdAt: new Date().toISOString(),
+    };
+
+    expect(metadata.status).toBe("starting");
+    expect(metadata.createdAt).toBeDefined();
+  });
+
+  test("creates full metadata with health tracking", () => {
+    const now = new Date().toISOString();
+    const metadata: VmMetadata = {
+      task: "test task",
+      approach: "approach A",
+      status: "ready",
+      createdAt: now,
+      parentId: "parent-vm-id",
+      lastHealthCheckAt: now,
+      lastEventAt: now,
+      healthScore: 100,
+      consecutiveFailures: 0,
+      lastError: undefined,
+      recoveryAttempts: 0,
+    };
+
+    expect(metadata.task).toBe("test task");
+    expect(metadata.approach).toBe("approach A");
+    expect(metadata.status).toBe("ready");
+    expect(metadata.parentId).toBe("parent-vm-id");
+    expect(metadata.lastHealthCheckAt).toBe(now);
+    expect(metadata.lastEventAt).toBe(now);
+    expect(metadata.healthScore).toBe(100);
+    expect(metadata.consecutiveFailures).toBe(0);
+    expect(metadata.recoveryAttempts).toBe(0);
+  });
+
+  test("creates unhealthy metadata", () => {
+    const metadata: VmMetadata = {
+      status: "unhealthy",
+      createdAt: new Date().toISOString(),
+      healthScore: 0,
+      consecutiveFailures: 5,
+      lastError: "Connection refused",
+    };
+
+    expect(metadata.status).toBe("unhealthy");
+    expect(metadata.healthScore).toBe(0);
+    expect(metadata.consecutiveFailures).toBe(5);
+    expect(metadata.lastError).toBe("Connection refused");
+  });
+
+  test("creates recovering metadata", () => {
+    const metadata: VmMetadata = {
+      status: "recovering",
+      createdAt: new Date().toISOString(),
+      recoveryAttempts: 2,
+    };
+
+    expect(metadata.status).toBe("recovering");
+    expect(metadata.recoveryAttempts).toBe(2);
+  });
+});
+
+describe("Health score calculation", () => {
+  test("100 for no failures", () => {
+    const failures = 0;
+    const healthScore = Math.max(0, 100 - (failures * 33));
+    expect(healthScore).toBe(100);
+  });
+
+  test("67 for 1 failure", () => {
+    const failures = 1;
+    const healthScore = Math.max(0, 100 - (failures * 33));
+    expect(healthScore).toBe(67);
+  });
+
+  test("34 for 2 failures", () => {
+    const failures = 2;
+    const healthScore = Math.max(0, 100 - (failures * 33));
+    expect(healthScore).toBe(34);
+  });
+
+  test("1 for 3 failures", () => {
+    const failures = 3;
+    const healthScore = Math.max(0, 100 - (failures * 33));
+    expect(healthScore).toBe(1);
+  });
+
+  test("0 for 4+ failures", () => {
+    const failures = 4;
+    const healthScore = Math.max(0, 100 - (failures * 33));
+    expect(healthScore).toBe(0);
+  });
+});

--- a/tests/orchestrator/monitoring-config.test.ts
+++ b/tests/orchestrator/monitoring-config.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// Mock the config directory for tests
+const TEST_CONFIG_DIR = join(homedir(), ".vers-agent-test", "orchestrator");
+const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, "monitoring.json");
+
+// We need to test the config module in isolation
+// Import after setting up mocks would be ideal, but for now test the logic
+
+describe("monitoring-config", () => {
+  beforeEach(() => {
+    // Clean up test directory
+    if (existsSync(TEST_CONFIG_DIR)) {
+      rmSync(TEST_CONFIG_DIR, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    if (existsSync(TEST_CONFIG_DIR)) {
+      rmSync(TEST_CONFIG_DIR, { recursive: true });
+    }
+  });
+
+  describe("DEFAULT_HEALTH_CONFIG", () => {
+    test("has sensible defaults", async () => {
+      const { DEFAULT_HEALTH_CONFIG } = await import("../../src/orchestrator/monitoring-config");
+
+      expect(DEFAULT_HEALTH_CONFIG.intervalMs).toBe(30000);
+      expect(DEFAULT_HEALTH_CONFIG.timeoutMs).toBe(5000);
+      expect(DEFAULT_HEALTH_CONFIG.unhealthyThreshold).toBe(3);
+      expect(DEFAULT_HEALTH_CONFIG.eventTimeoutMs).toBe(120000);
+    });
+  });
+
+  describe("DEFAULT_WATCHDOG_CONFIG", () => {
+    test("has sensible defaults", async () => {
+      const { DEFAULT_WATCHDOG_CONFIG } = await import("../../src/orchestrator/monitoring-config");
+
+      expect(DEFAULT_WATCHDOG_CONFIG.intervalMs).toBe(300000);
+      expect(DEFAULT_WATCHDOG_CONFIG.staleMetadataAgeMs).toBe(86400000);
+      expect(DEFAULT_WATCHDOG_CONFIG.staleBranchAgeMs).toBe(3600000);
+      expect(DEFAULT_WATCHDOG_CONFIG.maxBranchesPerRoot).toBe(20);
+    });
+  });
+
+  describe("DEFAULT_MONITORING_CONFIG", () => {
+    test("is enabled by default", async () => {
+      const { DEFAULT_MONITORING_CONFIG } = await import("../../src/orchestrator/monitoring-config");
+
+      expect(DEFAULT_MONITORING_CONFIG.enabled).toBe(true);
+      expect(DEFAULT_MONITORING_CONFIG.health).toBeDefined();
+      expect(DEFAULT_MONITORING_CONFIG.watchdog).toBeDefined();
+    });
+  });
+});

--- a/tests/orchestrator/watchdog.test.ts
+++ b/tests/orchestrator/watchdog.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { Watchdog } from "../../src/orchestrator/watchdog";
+
+describe("Watchdog", () => {
+  let watchdog: Watchdog;
+
+  beforeEach(() => {
+    watchdog = new Watchdog({
+      intervalMs: 1000,
+      staleMetadataAgeMs: 60000,
+      staleBranchAgeMs: 30000,
+      maxBranchesPerRoot: 5,
+    });
+  });
+
+  afterEach(() => {
+    watchdog.stop();
+  });
+
+  describe("constructor", () => {
+    test("creates with default config", () => {
+      const wd = new Watchdog();
+      expect(wd).toBeDefined();
+      expect(wd.isRunning()).toBe(false);
+      wd.stop();
+    });
+
+    test("creates with custom config", () => {
+      const wd = new Watchdog({
+        intervalMs: 10000,
+        maxBranchesPerRoot: 10,
+      });
+      expect(wd).toBeDefined();
+      wd.stop();
+    });
+  });
+
+  describe("start/stop", () => {
+    test("starts and stops correctly", () => {
+      expect(watchdog.isRunning()).toBe(false);
+
+      watchdog.start();
+      expect(watchdog.isRunning()).toBe(true);
+
+      watchdog.stop();
+      expect(watchdog.isRunning()).toBe(false);
+    });
+
+    test("handles multiple start calls", () => {
+      watchdog.start();
+      watchdog.start(); // Should not throw
+      expect(watchdog.isRunning()).toBe(true);
+    });
+
+    test("handles multiple stop calls", () => {
+      watchdog.start();
+      watchdog.stop();
+      watchdog.stop(); // Should not throw
+      expect(watchdog.isRunning()).toBe(false);
+    });
+  });
+});
+
+describe("ConsistencyReport", () => {
+  test("has correct structure", () => {
+    const report = {
+      vmCount: 5,
+      metadataCount: 4,
+      orphanedMetadata: ["vm-1"],
+      missingMetadata: ["vm-5", "vm-6"],
+      staleBranches: ["vm-2"],
+      finishedBranches: ["vm-3"],
+    };
+
+    expect(report.vmCount).toBe(5);
+    expect(report.metadataCount).toBe(4);
+    expect(report.orphanedMetadata).toHaveLength(1);
+    expect(report.missingMetadata).toHaveLength(2);
+    expect(report.staleBranches).toHaveLength(1);
+    expect(report.finishedBranches).toHaveLength(1);
+  });
+});
+
+describe("CleanupResult", () => {
+  test("has correct structure", () => {
+    const result = {
+      metadataRemoved: 3,
+      vmsDeleted: 2,
+      errors: ["error 1"],
+    };
+
+    expect(result.metadataRemoved).toBe(3);
+    expect(result.vmsDeleted).toBe(2);
+    expect(result.errors).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Part A (non-experimental) of autonomous operation for the VM orchestrator:

- **Health Monitor**: Periodic health checks via SSH, tracks failures, marks VMs unhealthy
- **Watchdog**: Cleans up orphaned metadata, prunes old branches, consistency checks
- **Extended VmMetadata**: New health tracking fields and statuses (`unhealthy`, `recovering`)

## Changes

| File | Description |
|------|-------------|
| `src/orchestrator/health-monitor.ts` | New - periodic health checks |
| `src/orchestrator/watchdog.ts` | New - cleanup and consistency |
| `src/orchestrator/monitoring-config.ts` | New - config types and persistence |
| `src/orchestrator/index.ts` | Extended metadata, added `startMonitoring()`/`stopMonitoring()` |
| `src/protocol/acp-types.ts` | Extended VmInfo with new statuses |
| `tests/orchestrator/*.ts` | 33 new tests |

## Usage

```typescript
import { startMonitoring, stopMonitoring } from "./src/orchestrator";

// Start with defaults (30s health checks, 5min watchdog)
startMonitoring();

// Or with custom config
startMonitoring({
  health: { intervalMs: 10000, unhealthyThreshold: 5 },
  watchdog: { intervalMs: 60000 }
});

// Stop when done
stopMonitoring();
```

## Test plan

- [x] Unit tests pass (593 total, 33 new)
- [x] Typecheck passes
- [x] Manual test with real VM - health checks work, metrics parsed correctly

🤖 Generated with [Claude Code](https://claude.ai/code) on [VERS](https://vers.sh)